### PR TITLE
added redis to solve horizontal-scaling issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
 import { Server, Socket } from "socket.io";
 import dotenv from 'dotenv';
 dotenv.config();
+import Redis  from "ioredis";
 
-import Connection from './database/db.js'
+const pub = new Redis(process.env.REDIS_URI);
+const sub = new Redis(process.env.REDIS_URI);
+
+// import Connection from './database/db.js'
 
 import docController from "./controller/docController.js";
-import { updateDoc } from "./controller/docController.js";
+// import { updateDoc } from "./controller/docController.js";
 // const PORT = 9000;
 
-Connection(process.env.URL);
+// Connection(process.env.URL);
 
 const io = new Server(process.env.PORT, {
   cors: {
@@ -17,23 +21,34 @@ const io = new Server(process.env.PORT, {
   },
 });
 
+sub.subscribe("MESSAGES");
+sub.on("message", (channel, message)=>{
+  if (channel === "MESSAGES") {
+    console.log("new message from redis", message);
+    const { delta, docId, senderId } = JSON.parse(message);
+    io.sockets.sockets.get(senderId).broadcast.to(docId).emit("receive-changes", delta);
+  }
+})
 io.on("connection", (socket) => {
+
+  console.log("connected");
   socket.on("get-document", async(docId) => {
-    const document = await docController(docId)
+    // const document = await docController(docId)
     socket.join(docId);
-    socket.emit("load-document", document.data);
+    // socket.emit("load-document", document.data);
+    socket.emit("load-document", "hello");
     
-    socket.on("send-changes", (delta) => {
-      // console.log('delta', delta);
-      socket.broadcast.to(docId).emit("receive-changes", delta);
+    socket.on("send-changes", async(delta) => {
+      console.log('delta', delta, docId);
+      await pub.publish('MESSAGES', JSON.stringify({delta, docId, senderId: socket.id}));
+          // socket.broadcast.to(docId).emit("receive-changes", delta);
+        });
+        
+        socket.on('save-document', async (data,name)=>{
+          console.log("name coming", data);
+          // await updateDoc(docId, data);
+        });
+      });
+      
     });
     
-    socket.on('save-document', async (data,name)=>{
-      console.log("name coming");
-      await updateDoc(docId, data);
-    });
-  });
-  socket.on('anmol',(name)=>{
-    console.log('name is '+name);
-  })
-});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.0.3",
+    "ioredis": "^5.3.2",
     "mongoose": "^7.2.0",
     "nodemon": "^2.0.22",
     "socket.io": "^4.6.1"


### PR DESCRIPTION
Redis will allow multiple socket server to subscribe to changes that one user makes, 
Then we can publish the changes in the redis server, due to its high throughput, and then all the servers (horizontally scaled), will be able to get the changes made by one user, even though they are connected to different socket server, due to redis being at the top of all the server and all the servers being subscribed to the central redis.